### PR TITLE
Declare the two API bases that are alive but 404 on a bare GET

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,3 +170,20 @@ packages = ["know_your_ip"]
 [tool.uv-dynamic-versioning]
 vcs = "git"
 style = "pep440"
+
+[tool.preen]
+# Two API bases here are alive but only answer with a path, so fetching them
+# bare reports a dead link for an endpoint this package uses successfully:
+#
+#   rdap.arin.net/registry/            -> 404
+#   rdap.arin.net/registry/ip/8.8.8.8  -> 200   (what the code actually calls)
+#   api.platform.censys.io             -> 404   (called as /v3/global/asset/...)
+#
+# Written without schemes on purpose: a full URL in this comment is itself
+# extracted and checked, so documenting the problem here would recreate it.
+#
+# Narrower than skip_checks = ["links"], which would also stop checking README.
+link_ignore = [
+    "rdap\\.arin\\.net",
+    "api\\.platform\\.censys\\.io",
+]


### PR DESCRIPTION
preen's links check reported four dead links here. All four were the same two endpoints, and **neither is dead**:

```
rdap.arin.net/registry/            -> 404
rdap.arin.net/registry/ip/8.8.8.8  -> 200     <- what know_your_ip actually calls
api.platform.censys.io             -> 404     <- called as /v3/global/asset/host/...
```

They are API bases that only answer with a path, and the check fetches them bare.

## The fix

Declared in `[tool.preen] link_ignore`, which gojiplus/preen#39 added for exactly this case. Narrower than `skip_checks = ["links"]`, which would also stop checking the README — where a broken link actually costs a reader something.

## One thing worth knowing

The comment naming the endpoints omits the `https://` schemes deliberately. Written as full URLs they get extracted and checked like any other text in the file, so **the note explaining the problem recreates it** — the first draft of this block added two fresh dead links to the report:

```
[error] links: Dead link: https://rdap/ - Connection failed
```

**`preen check --strict` now exits 0.** `ruff check`, `ruff format --check`, full test suite pass.

Part of a fleet-wide conformance pass from gojiplus/py-canon.