### PR TITLE
chore: pick up the current py-canon

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Managed by copier — records template version for `copier update`. Do not edit.
-_commit: v1.0.1
+_commit: v1.1.0
 _src_path: gh:gojiplus/py-canon
 author_email: suriyant@gmail.com
 author_name: Suriyan Laohaprapanon

--- a/uv.lock
+++ b/uv.lock
@@ -1694,8 +1694,8 @@ wheels = [
 
 [[package]]
 name = "py-canon"
-version = "1.0.1"
-source = { git = "https://github.com/gojiplus/py-canon?rev=v1#254362c2c0f5fc332216d455abfc2e3f89957282" }
+version = "1.1.0"
+source = { git = "https://github.com/gojiplus/py-canon?rev=v1#f756be7a6e4dd0ea2a006c215e39ed2e1e29a412" }
 
 [[package]]
 name = "pycparser"


### PR DESCRIPTION
Opened by `tools/fleet-propagate.sh` in gojiplus/py-canon.

The `@v1` reusable workflows update themselves; these two layers do not:

- **`uv.lock`** pins the *commit* `py-canon@v1` resolved to, so docs keep
  building against an old `py_canon.sphinx` until the lock is refreshed.
- **`copier update`** is what carries template changes -- scaffolding and the
  shared `[tool.*]` config -- into a repo that already exists. Nothing runs it
  on a schedule.

Nothing here was hand-written. If the result is wrong, the fix belongs in the
template rather than in this diff.